### PR TITLE
client: use new faraday syntax to avoid warnings

### DIFF
--- a/lib/datacite/client.rb
+++ b/lib/datacite/client.rb
@@ -19,7 +19,7 @@ module Datacite
         headers: headers
       ) do |conn|
         conn.request :json
-        conn.basic_auth(username, password)
+        conn.request(:basic_auth, username, password)
         conn.response :json
       end
     end


### PR DESCRIPTION
## Why was this change made?

To avoid this:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

## How was this change tested?

analogous change made in infra-int tests

## Which documentation and/or configurations were updated?



