### PR TITLE
Simplify Zeitwerk setup

### DIFF
--- a/lib/datacite.rb
+++ b/lib/datacite.rb
@@ -2,11 +2,7 @@
 
 require "zeitwerk"
 
-loader = Zeitwerk::Loader.new
-loader.tag = File.basename(__FILE__, ".rb")
-loader.inflector = Zeitwerk::GemInflector.new(__FILE__)
-loader.push_dir(__dir__)
-loader.setup
+Zeitwerk::Loader.for_gem.setup
 
 module Datacite
   class Error < StandardError; end


### PR DESCRIPTION
Hey! Just saw this configuration in passing.

`datacite-ruby` follows perfectly all conventions, so `for_gem` is the way to go if you like that simple one-liner.

Of course, if the explicit setup was deliberate, please disregard this patch :).