### PR TITLE
Allow for passing of xml as part of the payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ We've made the following changes:
   * relax the required fields (https://github.com/datacite/schema/issues/97)
   * add event property (https://github.com/datacite/schema/issues/100)
   * add url property (https://github.com/datacite/schema/issues/101)
+  * add xml property to support Datacite 4.4 xml schema via the api (https://github.com/datacite/schema/issues/99)
 
 ## Development
 

--- a/lib/datacite/schema.json
+++ b/lib/datacite/schema.json
@@ -475,6 +475,9 @@
         "schemaVersion": {
             "type": "string",
             "const": "http://datacite.org/schema/kernel-4"
+        },
+        "xml": {
+            "type": "string"
         }
     },
     "additionalProperties": false

--- a/spec/datacite/client_spec.rb
+++ b/spec/datacite/client_spec.rb
@@ -456,5 +456,55 @@ RSpec.describe Datacite::Client do
         )
       end
     end
+
+    context "when the request is in xml" do
+      let(:xml) do
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" \
+          "<resource xmlns=\"http://datacite.org/schema/kernel-4\" " \
+                     "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " \
+                     "xsi:schemaLocation=\"http://datacite.org/schema/kernel-4
+                     http://schema.datacite.org/meta/kernel-4/metadata.xsd\">" \
+          "<identifier identifierType=\"DOI\">10.5438/bc123df4567</identifier>"\
+          "<creators><creator><creatorName>DataCite Metadata Working Group</creatorName></creator></creators>" \
+          "<titles>" \
+            "<title>DataCite Metadata Schema Documentation for the Publication and Citation of Research Data v4.0" \
+          "</title></titles>" \
+          "<publisher>DataCite e.V.</publisher><publicationYear>2016</publicationYear>"\
+          "<resourceType resourceTypeGeneral=\"Text\">Documentation</resourceType>" \
+          "<relatedIdentifiers>" \
+            "<relatedIdentifier relatedIdentifierType=\"URL\" relationType=\"HasMetadata\"" \
+              "relatedMetadataScheme=\"citeproc+json\" " \
+              "schemeURI=\"https://github.com/citation-style-language/schema/raw/master/csl-data.json\">"\
+              "https://data.datacite.org/application/citeproc+json/10.5072/example-full</relatedIdentifier>" \
+            "<relatedIdentifier relatedIdentifierType=\"arXiv\" relationType=\"IsReviewedBy\" " \
+              "resourceTypeGeneral=\"Text\">arXiv:0706.0001</relatedIdentifier>" \
+          "</relatedIdentifiers> " \
+          "</resource>"
+      end
+      let(:attributes) do
+        {
+          "event" => "publish",
+          "url" => "https://purl.stanford.edu/st435qh3132",
+          "xml" => Base64.encode64(xml)
+        }
+      end
+
+      let(:json_xml_attribute) { JSON.generate(Base64.encode64(xml)) }
+
+      let(:request_body) do
+        <<~JSON
+          {"data":{"attributes":{"event":"publish","url":"https://purl.stanford.edu/st435qh3132","xml":#{json_xml_attribute}}}}
+        JSON
+      end
+
+      let(:status) { 200 }
+      let(:response) do
+        nil
+      end
+
+      it "can update the DOI" do
+        expect { generate }.not_to raise_error JsonSchema::AggregateError
+      end
+    end
   end
 end


### PR DESCRIPTION
xml is allowed via the api: https://support.datacite.org/docs/api-create-dois#provide-metadata-in-formats-other-than-json

## Why was this change made?

This is needed to support Datacite version 4.4 xml format properties prior to a new json schema being released.

I'm proposing this change to allow for XML in the json payload.  If this is something y'all would like to support I can create a more fully functional PR. 

## How was this change tested?

Tested via api call to Princeton Data Commons Staging Datacite (see https://github.com/pulibrary/pdc_describe/pull/251)

Automated testing in spec/datacite/client_spec.rb

## Which documentation and/or configurations were updated?

Readme was updated to include information on the xml field


