### PR TITLE
update ruby version to >=3.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7 # dor-service-app is < 3.0 due to fedora3
+  TargetRubyVersion: 3.0
 
 Metrics/BlockLength:
   Exclude:

--- a/datacite.gemspec
+++ b/datacite.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "A Ruby client library for the DataCite REST API "
   spec.description   = "See https://support.datacite.org/docs/api"
   spec.homepage      = "https://github.com/sul-dlss/datacite-ruby"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0"
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 


### PR DESCRIPTION
## Why was this change made?

We're on ruby 3.0 now.  Yay!

## How was this change tested?

rubocop

## Which documentation and/or configurations were updated?



