### PR TITLE
development dependencies in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - datacite.gemspec
     - spec/**/*_spec.rb
 
 Style/StringLiterals:

--- a/Gemfile
+++ b/Gemfile
@@ -4,15 +4,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in datacite.gemspec
 gemspec
-
-gem "rake", "~> 13.0"
-
-gem "rspec", "~> 3.0"
-
-gem "rubocop", "~> 1.7"
-
-gem "rubocop-rake", "~> 0.6.0"
-gem "rubocop-rspec", "~> 2.4"
-
-gem "byebug"
-gem "webmock", "~> 3.13"

--- a/datacite.gemspec
+++ b/datacite.gemspec
@@ -33,4 +33,12 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schema", "~> 0.21.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop", "~> 1.7"
+  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
+  spec.add_development_dependency "rubocop-rspec", "~> 2.4"
+  spec.add_development_dependency "webmock", "~> 3.13"
 end


### PR DESCRIPTION
## Why was this change made?

the accepted practice (I did some web research on this) is to put development dependencies in the gemspec, which matches the bulk of our gems, I believe.

## How was this change tested?



## Which documentation and/or configurations were updated?



