### PR TITLE
Rubocops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rake
+  - rubocop-rspec
 
 AllCops:
   TargetRubyVersion: 2.7 # dor-service-app is < 3.0 due to fedora3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,3 +121,34 @@ Style/RedundantSelfAssignmentBranch: # new in 1.19
   Enabled: true
 Style/SelectByRegexp: # new in 1.22
   Enabled: true
+
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Lint/ConstantOverwrittenInRescue: # new in 1.31
+  Enabled: true
+Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/RefinementImportMethods: # new in 1.27
+  Enabled: true
+Lint/RequireRangeParentheses: # new in 1.32
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,9 +1,17 @@
+require: rubocop-rspec
+
 AllCops:
   TargetRubyVersion: 2.7 # dor-service-app is < 3.0 due to fedora3
 
 Metrics/BlockLength:
   Exclude:
     - spec/**/*_spec.rb
+
+RSpec/MultipleExpectations:
+  Max: 5 # default 1
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
 
 Style/StringLiterals:
   Enabled: true
@@ -151,4 +159,33 @@ Style/NestedFileDirname: # new in 1.26
 Style/ObjectThen: # new in 1.28
   Enabled: true
 Style/RedundantInitialize: # new in 1.27
+  Enabled: true
+
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11
+  Enabled: true
+RSpec/ClassCheck: # new in 2.13
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
+RSpec/NoExpectationExample: # new in 2.13
+  Enabled: true
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true
+RSpec/Capybara/SpecificFinders: # new in 2.13
+  Enabled: true
+RSpec/Capybara/SpecificMatcher: # new in 2.12
+  Enabled: true
+RSpec/FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: true
+RSpec/Rails/HaveHttpStatus: # new in 2.12
   Enabled: true

--- a/spec/datacite/client_spec.rb
+++ b/spec/datacite/client_spec.rb
@@ -464,17 +464,17 @@ RSpec.describe Datacite::Client do
                      "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " \
                      "xsi:schemaLocation=\"http://datacite.org/schema/kernel-4
                      http://schema.datacite.org/meta/kernel-4/metadata.xsd\">" \
-          "<identifier identifierType=\"DOI\">10.5438/bc123df4567</identifier>"\
+          "<identifier identifierType=\"DOI\">10.5438/bc123df4567</identifier>" \
           "<creators><creator><creatorName>DataCite Metadata Working Group</creatorName></creator></creators>" \
           "<titles>" \
             "<title>DataCite Metadata Schema Documentation for the Publication and Citation of Research Data v4.0" \
           "</title></titles>" \
-          "<publisher>DataCite e.V.</publisher><publicationYear>2016</publicationYear>"\
+          "<publisher>DataCite e.V.</publisher><publicationYear>2016</publicationYear>" \
           "<resourceType resourceTypeGeneral=\"Text\">Documentation</resourceType>" \
           "<relatedIdentifiers>" \
             "<relatedIdentifier relatedIdentifierType=\"URL\" relationType=\"HasMetadata\"" \
               "relatedMetadataScheme=\"citeproc+json\" " \
-              "schemeURI=\"https://github.com/citation-style-language/schema/raw/master/csl-data.json\">"\
+              "schemeURI=\"https://github.com/citation-style-language/schema/raw/master/csl-data.json\">" \
               "https://data.datacite.org/application/citeproc+json/10.5072/example-full</relatedIdentifier>" \
             "<relatedIdentifier relatedIdentifierType=\"arXiv\" relationType=\"IsReviewedBy\" " \
               "resourceTypeGeneral=\"Text\">arXiv:0706.0001</relatedIdentifier>" \

--- a/spec/datacite/client_spec.rb
+++ b/spec/datacite/client_spec.rb
@@ -290,6 +290,8 @@ RSpec.describe Datacite::Client do
   end
 
   describe "#update" do
+    subject(:generate) { client.update(id: "10.5438/bc123df4567", attributes: attributes) }
+
     let(:attributes) do
       {
         "event" => "publish",
@@ -309,7 +311,6 @@ RSpec.describe Datacite::Client do
         {"data":{"attributes":{"event":"publish","url":"https://purl.stanford.edu/st435qh3132","relatedIdentifiers":[{"relatedIdentifier":"https://doi.org/10.xxxx/xxxxx","relatedIdentifierType":"DOI","relationType":"References","resourceTypeGeneral":"Dataset"}]}}}
       JSON
     end
-    subject(:generate) { client.update(id: "10.5438/bc123df4567", attributes: attributes) }
 
     before do
       stub_request(:put, "https://api.test.datacite.org/dois/10.5438/bc123df4567")

--- a/spec/datacite_spec.rb
+++ b/spec/datacite_spec.rb
@@ -2,6 +2,6 @@
 
 RSpec.describe Datacite do
   it "has a version number" do
-    expect(Datacite::VERSION).not_to be nil
+    expect(Datacite::VERSION).not_to be_nil
   end
 end


### PR DESCRIPTION
## Why was this change made?

- actually use rubocop-rspec
- actually use rubocop-rake
- keep our rubocops up to date

## How was this change tested?



## Which documentation and/or configurations were updated?



