### PR TITLE
Enable new rubocops and update Gemfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,181 +27,99 @@ Style/StringLiteralsInInterpolation:
 Layout/LineLength:
   Max: 120
 
-Gemspec/DeprecatedAttributeAssignment: # (new in 1.10)
+Gemspec/DeprecatedAttributeAssignment: # new in 1.30
   Enabled: true
-Layout/LineEndStringConcatenationIndentation: # (new in 1.18)
+Gemspec/DevelopmentDependencies: # new in 1.44
   Enabled: true
-Layout/SpaceBeforeBrackets: # (new in 1.7)
-  Enabled: true
-Lint/AmbiguousAssignment: # (new in 1.7)
-  Enabled: true
-Lint/DeprecatedConstants: # (new in 1.8)
-  Enabled: true
-Lint/DuplicateBranch: # (new in 1.3)
-  Enabled: true
-Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
-  Enabled: true
-Lint/EmptyBlock: # (new in 1.1)
-  Enabled: true
-Lint/EmptyClass: # (new in 1.3)
-  Enabled: true
-Lint/EmptyInPattern: # (new in 1.16)
-  Enabled: true
-Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
-  Enabled: true
-Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
-  Enabled: true
-Lint/NumberedParameterAssignment: # (new in 1.9)
-  Enabled: true
-Lint/OrAssignmentToConstant: # (new in 1.9)
-  Enabled: true
-Lint/RedundantDirGlobSort: # (new in 1.8)
-  Enabled: true
-Lint/SymbolConversion: # (new in 1.9)
-  Enabled: true
-Lint/ToEnumArguments: # (new in 1.1)
-  Enabled: true
-Lint/TripleQuotes: # (new in 1.9)
-  Enabled: true
-Lint/UnexpectedBlockArity: # (new in 1.5)
-  Enabled: true
-Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
-  Enabled: true
-Naming/InclusiveLanguage: # (new in 1.18)
-  Enabled: true
-Style/ArgumentsForwarding: # (new in 1.1)
-  Enabled: true
-Style/CollectionCompact: # (new in 1.2)
-  Enabled: true
-Style/DocumentDynamicEvalDefinition: # (new in 1.1)
-  Enabled: true
-Style/EndlessMethod: # (new in 1.8)
-  Enabled: true
-Style/HashConversion: # (new in 1.10)
-  Enabled: true
-Style/HashExcept: # (new in 1.7)
-  Enabled: true
-Style/IfWithBooleanLiteralBranches: # (new in 1.9)
-  Enabled: true
-Style/InPatternThen: # (new in 1.16)
-  Enabled: true
-Style/MultilineInPatternThen: # (new in 1.16)
-  Enabled: true
-Style/NegatedIfElseCondition: # (new in 1.2)
-  Enabled: true
-Style/NilLambda: # (new in 1.3)
-  Enabled: true
-Style/QuotedSymbols: # (new in 1.16)
-  Enabled: true
-Style/RedundantArgument: # (new in 1.4)
-  Enabled: true
-Style/StringChars: # (new in 1.12)
-  Enabled: true
-Style/SwapValues: # (new in 1.1)
-  Enabled: true
-
 Gemspec/RequireMFA: # new in 1.23
+  Enabled: true
+Layout/LineContinuationLeadingSpace: # new in 1.31
+  Enabled: true
+Layout/LineContinuationSpacing: # new in 1.31
+  Enabled: true
+Layout/LineEndStringConcatenationIndentation: # new in 1.18
+  Enabled: true
+Layout/SpaceBeforeBrackets: # new in 1.7
+  Enabled: true
+Lint/AmbiguousAssignment: # new in 1.7
   Enabled: true
 Lint/AmbiguousOperatorPrecedence: # new in 1.21
   Enabled: true
 Lint/AmbiguousRange: # new in 1.19
   Enabled: true
-Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
-  Enabled: true
-Lint/RequireRelativeSelfPath: # new in 1.22
-  Enabled: true
-Lint/UselessRuby2Keywords: # new in 1.23
-  Enabled: true
-Naming/BlockForwarding: # new in 1.24
-  Enabled: true
-Security/IoMethods: # new in 1.22
-  Enabled: true
-Style/FileRead: # new in 1.24
-  Enabled: true
-Style/FileWrite: # new in 1.24
-  Enabled: true
-Style/MapToHash: # new in 1.24
-  Enabled: true
-Style/NumberedParameters: # new in 1.22
-  Enabled: true
-Style/NumberedParametersLimit: # new in 1.22
-  Enabled: true
-Style/OpenStructUse: # new in 1.23
-  Enabled: true
-Style/RedundantSelfAssignmentBranch: # new in 1.19
-  Enabled: true
-Style/SelectByRegexp: # new in 1.22
-  Enabled: true
-
-Layout/LineContinuationLeadingSpace: # new in 1.31
-  Enabled: true
-Layout/LineContinuationSpacing: # new in 1.31
-  Enabled: true
 Lint/ConstantOverwrittenInRescue: # new in 1.31
   Enabled: true
+Lint/DeprecatedConstants: # new in 1.8
+  Enabled: true
+Lint/DuplicateBranch: # new in 1.3
+  Enabled: true
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+Lint/DuplicateMatchPattern: # new in 1.50
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # new in 1.1
+  Enabled: true
+Lint/EmptyBlock: # new in 1.1
+  Enabled: true
+Lint/EmptyClass: # new in 1.3
+  Enabled: true
+Lint/EmptyInPattern: # new in 1.16
+  Enabled: true
+Lint/IncompatibleIoSelectWithFiberScheduler: # new in 1.21
+  Enabled: true
+Lint/ItWithoutArgumentsInBlock: # new in 1.59
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # new in 1.8
+  Enabled: true
+Lint/LiteralAssignmentInCondition: # new in 1.58
+  Enabled: true
+Lint/MixedCaseRange: # new in 1.53
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # new in 1.2
+  Enabled: true
 Lint/NonAtomicFileOperation: # new in 1.31
+  Enabled: true
+Lint/NumberedParameterAssignment: # new in 1.9
+  Enabled: true
+Lint/OrAssignmentToConstant: # new in 1.9
+  Enabled: true
+Lint/RedundantDirGlobSort: # new in 1.8
+  Enabled: true
+Lint/RedundantRegexpQuantifiers: # new in 1.53
   Enabled: true
 Lint/RefinementImportMethods: # new in 1.27
   Enabled: true
 Lint/RequireRangeParentheses: # new in 1.32
   Enabled: true
-Security/CompoundHash: # new in 1.28
+Lint/RequireRelativeSelfPath: # new in 1.22
   Enabled: true
-Style/EmptyHeredoc: # new in 1.32
+Lint/SymbolConversion: # new in 1.9
   Enabled: true
-Style/EnvHome: # new in 1.29
+Lint/ToEnumArguments: # new in 1.1
   Enabled: true
-Style/FetchEnvVar: # new in 1.28
+Lint/TripleQuotes: # new in 1.9
   Enabled: true
-Style/MagicCommentFormat: # new in 1.35
+Lint/UnexpectedBlockArity: # new in 1.5
   Enabled: true
-Style/MapCompactWithConditionalBlock: # new in 1.30
-  Enabled: true
-Style/NestedFileDirname: # new in 1.26
-  Enabled: true
-Style/ObjectThen: # new in 1.28
-  Enabled: true
-Style/RedundantInitialize: # new in 1.27
-  Enabled: true
-
-RSpec/BeEq: # new in 2.9.0
-  Enabled: true
-RSpec/BeNil: # new in 2.9.0
-  Enabled: true
-RSpec/ChangeByZero: # new in 2.11
-  Enabled: true
-RSpec/ClassCheck: # new in 2.13
-  Enabled: true
-RSpec/ExcessiveDocstringSpacing: # new in 2.5
-  Enabled: true
-RSpec/IdenticalEqualityAssertion: # new in 2.4
-  Enabled: true
-RSpec/NoExpectationExample: # new in 2.13
-  Enabled: true
-RSpec/SubjectDeclaration: # new in 2.5
-  Enabled: true
-RSpec/VerifiedDoubleReference: # new in 2.10.0
-  Enabled: true
-Capybara/SpecificFinders: # new in 2.13
-  Enabled: true
-Capybara/SpecificMatcher: # new in 2.12
-  Enabled: true
-FactoryBot/SyntaxMethods: # new in 2.7
-  Enabled: true
-RSpec/Rails/AvoidSetupHook: # new in 2.4
-  Enabled: true
-RSpec/Rails/HaveHttpStatus: # new in 2.12
-  Enabled: true
-
-Lint/DuplicateMagicComment: # new in 1.37
-  Enabled: true
-Lint/DuplicateMatchPattern: # new in 1.50
+Lint/UnmodifiedReduceAccumulator: # new in 1.1
   Enabled: true
 Lint/UselessRescue: # new in 1.43
   Enabled: true
+Lint/UselessRuby2Keywords: # new in 1.23
+  Enabled: true
 Metrics/CollectionLiteralLength: # new in 1.47
   Enabled: true
+Naming/BlockForwarding: # new in 1.24
+  Enabled: true
+Security/CompoundHash: # new in 1.28
+  Enabled: true
+Security/IoMethods: # new in 1.22
+  Enabled: true
+Style/ArgumentsForwarding: # new in 1.1
+  Enabled: true
 Style/ArrayIntersect: # new in 1.40
+  Enabled: true
+Style/CollectionCompact: # new in 1.2
   Enabled: true
 Style/ComparableClamp: # new in 1.44
   Enabled: true
@@ -211,19 +129,69 @@ Style/DataInheritance: # new in 1.49
   Enabled: true
 Style/DirEmpty: # new in 1.48
   Enabled: true
+Style/DocumentDynamicEvalDefinition: # new in 1.1
+  Enabled: true
+Style/EmptyHeredoc: # new in 1.32
+  Enabled: true
+Style/EndlessMethod: # new in 1.8
+  Enabled: true
+Style/EnvHome: # new in 1.29
+  Enabled: true
 Style/ExactRegexpMatch: # new in 1.51
   Enabled: true
+Style/FetchEnvVar: # new in 1.28
+  Enabled: true
 Style/FileEmpty: # new in 1.48
+  Enabled: true
+Style/FileRead: # new in 1.24
+  Enabled: true
+Style/FileWrite: # new in 1.24
+  Enabled: true
+Style/HashConversion: # new in 1.10
+  Enabled: true
+Style/HashExcept: # new in 1.7
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # new in 1.9
+  Enabled: true
+Style/InPatternThen: # new in 1.16
+  Enabled: true
+Style/MagicCommentFormat: # new in 1.35
+  Enabled: true
+Style/MapCompactWithConditionalBlock: # new in 1.30
+  Enabled: true
+Style/MapToHash: # new in 1.24
   Enabled: true
 Style/MapToSet: # new in 1.42
   Enabled: true
 Style/MinMaxComparison: # new in 1.42
   Enabled: true
+Style/MultilineInPatternThen: # new in 1.16
+  Enabled: true
+Style/NegatedIfElseCondition: # new in 1.2
+  Enabled: true
+Style/NestedFileDirname: # new in 1.26
+  Enabled: true
+Style/NilLambda: # new in 1.3
+  Enabled: true
+Style/NumberedParameters: # new in 1.22
+  Enabled: true
+Style/NumberedParametersLimit: # new in 1.22
+  Enabled: true
+Style/ObjectThen: # new in 1.28
+  Enabled: true
+Style/OpenStructUse: # new in 1.23
+  Enabled: true
 Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+Style/QuotedSymbols: # new in 1.16
+  Enabled: true
+Style/RedundantArgument: # new in 1.4
   Enabled: true
 Style/RedundantArrayConstructor: # new in 1.52
   Enabled: true
 Style/RedundantConstantBase: # new in 1.40
+  Enabled: true
+Style/RedundantCurrentDirectoryInPath: # new in 1.53
   Enabled: true
 Style/RedundantDoubleSplatHashBraces: # new in 1.41
   Enabled: true
@@ -233,49 +201,125 @@ Style/RedundantFilterChain: # new in 1.52
   Enabled: true
 Style/RedundantHeredocDelimiterQuotes: # new in 1.45
   Enabled: true
+Style/RedundantInitialize: # new in 1.27
+  Enabled: true
 Style/RedundantLineContinuation: # new in 1.49
+  Enabled: true
+Style/RedundantRegexpArgument: # new in 1.53
   Enabled: true
 Style/RedundantRegexpConstructor: # new in 1.52
   Enabled: true
+Style/RedundantSelfAssignmentBranch: # new in 1.19
+  Enabled: true
 Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+Style/ReturnNilInPredicateMethodDefinition: # new in 1.53
+  Enabled: true
+Style/SelectByRegexp: # new in 1.22
+  Enabled: true
+Style/SingleLineDoEndBlock: # new in 1.57
+  Enabled: true
+Style/StringChars: # new in 1.12
+  Enabled: true
+Style/SuperWithArgsParentheses: # new in 1.58
+  Enabled: true
+Style/SwapValues: # new in 1.1
+  Enabled: true
+Style/YAMLFileRead: # new in 1.53
+  Enabled: true
+Capybara/ClickLinkOrButtonStyle: # new in 2.19
   Enabled: true
 Capybara/MatchStyle: # new in 2.17
   Enabled: true
 Capybara/NegationMatcher: # new in 2.14
   Enabled: true
+Capybara/RedundantWithinFind: # new in 2.20
+  Enabled: true
 Capybara/SpecificActions: # new in 2.14
+  Enabled: true
+Capybara/SpecificFinders: # new in 2.13
+  Enabled: true
+Capybara/SpecificMatcher: # new in 2.12
+  Enabled: true
+Capybara/RSpec/HaveSelector: # new in 2.19
+  Enabled: true
+Capybara/RSpec/PredicateMatcher: # new in 2.19
   Enabled: true
 FactoryBot/AssociationStyle: # new in 2.23
   Enabled: true
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: true
+FactoryBot/ExcessiveCreateList: # new in 2.25
+  Enabled: true
 FactoryBot/FactoryAssociationWithStrategy: # new in 2.23
   Enabled: true
 FactoryBot/FactoryNameStyle: # new in 2.16
   Enabled: true
+FactoryBot/IdSequence: # new in 2.24
+  Enabled: true
 FactoryBot/RedundantFactoryOption: # new in 2.23
   Enabled: true
+FactoryBot/SyntaxMethods: # new in 2.7
+  Enabled: true
 RSpec/BeEmpty: # new in 2.20
+  Enabled: true
+RSpec/BeEq: # new in 2.9.0
+  Enabled: true
+RSpec/BeNil: # new in 2.9.0
+  Enabled: true
+RSpec/ChangeByZero: # new in 2.11
   Enabled: true
 RSpec/ContainExactly: # new in 2.19
   Enabled: true
 RSpec/DuplicatedMetadata: # new in 2.16
   Enabled: true
+RSpec/EmptyMetadata: # new in 2.24
+  Enabled: true
+RSpec/Eq: # new in 2.24
+  Enabled: true
+RSpec/ExcessiveDocstringSpacing: # new in 2.5
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # new in 2.4
+  Enabled: true
 RSpec/IndexedLet: # new in 2.20
   Enabled: true
 RSpec/MatchArray: # new in 2.19
   Enabled: true
+RSpec/MetadataStyle: # new in 2.24
+  Enabled: true
+RSpec/NoExpectationExample: # new in 2.13
+  Enabled: true
 RSpec/PendingWithoutReason: # new in 2.16
   Enabled: true
+RSpec/ReceiveMessages: # new in 2.23
+  Enabled: true
 RSpec/RedundantAround: # new in 2.19
+  Enabled: true
+RSpec/RedundantPredicateMatcher: # new in 2.26
+  Enabled: true
+RSpec/RemoveConst: # new in 2.26
   Enabled: true
 RSpec/SkipBlockInsideExample: # new in 2.19
   Enabled: true
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
+RSpec/SpecFilePathFormat: # new in 2.24
+  Enabled: true
+RSpec/SpecFilePathSuffix: # new in 2.24
+  Enabled: true
+RSpec/SubjectDeclaration: # new in 2.5
+  Enabled: true
+RSpec/VerifiedDoubleReference: # new in 2.10.0
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # new in 2.4
+  Enabled: true
+RSpec/Rails/HaveHttpStatus: # new in 2.12
+  Enabled: true
 RSpec/Rails/InferredSpecType: # new in 2.14
   Enabled: true
 RSpec/Rails/MinitestAssertions: # new in 2.17
+  Enabled: true
+RSpec/Rails/NegationBeValid: # new in 2.23
   Enabled: true
 RSpec/Rails/TravelAround: # new in 2.19
   Enabled: true

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,12 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in datacite.gemspec
 gemspec
+
+# Specify development dependencies here
+gem "byebug"
+gem "rake", "~> 13.0"
+gem "rspec", "~> 3.0"
+gem "rubocop", "~> 1.7"
+gem "rubocop-rake", "~> 0.6.0"
+gem "rubocop-rspec", "~> 2.4"
+gem "webmock", "~> 3.13"

--- a/datacite.gemspec
+++ b/datacite.gemspec
@@ -33,12 +33,4 @@ Gem::Specification.new do |spec|
   spec.add_dependency "json_schema", "~> 0.21.0"
   spec.add_dependency "zeitwerk", "~> 2.4"
   spec.metadata["rubygems_mfa_required"] = "true"
-
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 1.7"
-  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-rspec", "~> 2.4"
-  spec.add_development_dependency "webmock", "~> 3.13"
 end


### PR DESCRIPTION
## Why was this change made?

Enable new cops, alphabetize the list cops being enabled, move dev dependencies into Gemfile per rubocop.

## How was this change tested?



## Which documentation and/or configurations were updated?



