### PR TITLE
Do not require credentials when using public API.

### DIFF
--- a/lib/datacite/client.rb
+++ b/lib/datacite/client.rb
@@ -12,13 +12,13 @@ module Datacite
     # @param [String] username
     # @param [String] password
     # @param [String] host
-    def initialize(username:, password:, host: "api.test.datacite.org")
+    def initialize(username: nil, password: nil, host: "api.test.datacite.org")
       @conn = Faraday.new(
         url: "https://#{host}",
         headers: headers
       ) do |conn|
         conn.request :json
-        conn.request :authorization, :basic, username, password
+        conn.request :authorization, :basic, username, password if username
         conn.response :json
       end
     end

--- a/spec/datacite/client_spec.rb
+++ b/spec/datacite/client_spec.rb
@@ -514,12 +514,15 @@ RSpec.describe Datacite::Client do
 
     before do
       stub_request(:head, "https://api.test.datacite.org/dois/10.5438/bc123df4567")
+        .with(headers: {
+                "Authorization" => "Basic Zm9vOmJhcg=="
+              })
         .to_return(status: status)
     end
 
-    context "when the DOI exists" do
-      let(:status) { 200 }
+    let(:status) { 200 }
 
+    context "when the DOI exists" do
       it "returns true" do
         expect(result.value!).to be true
       end
@@ -538,6 +541,19 @@ RSpec.describe Datacite::Client do
 
       it "returns a failure" do
         expect(result).to be_failure
+      end
+    end
+
+    context "when no username or password provided" do
+      subject(:client) { described_class.new }
+
+      before do
+        stub_request(:head, "https://api.test.datacite.org/dois/10.5438/bc123df4567")
+          .to_return(status: status).with { |request| request.headers["Authorization"].nil? }
+      end
+
+      it 'does not include the "Authorization" header' do
+        expect(result.value!).to be true
       end
     end
   end


### PR DESCRIPTION
## Why was this change made?
So that credentials aren't require when they're not needed.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?



