### PR TITLE
Update return for self_deposit_type to account for nil

### DIFF
--- a/lib/datacite/mapping/from_cocina/types.rb
+++ b/lib/datacite/mapping/from_cocina/types.rb
@@ -39,26 +39,33 @@ module Datacite
           end&.value
         end
 
-        # @return [String] DataCite resourceType value
+        # @return [String, nil] DataCite resourceType value
         def resource_type
-          @resource_type ||= begin
-            self_deposit_form = Array(description.form).find { |cocina_form| self_deposit_form?(cocina_form) }
-
-            subtypes = self_deposit_subtypes(self_deposit_form)
-            if subtypes.blank?
-              self_deposit_type(self_deposit_form)
-            else
-              subtypes.select { |subtype| subtype if subtype != resource_type_general }.join('; ')
-            end
-          end
+          @resource_type ||= resource_type_from_subtypes || resource_type_from_type
         end
 
-        # call with cocina form element for Stanford self deposit resource types
-        # @return String the value from the structuredValue when the type is 'type' for the cocina form element
+        def resource_type_from_subtypes
+          subtypes = self_deposit_subtypes(self_deposit_form)
+          return if subtypes.blank?
+
+          subtypes.reject { |subtype| subtype == resource_type_general }.join('; ')
+        end
+
+        def resource_type_from_type
+          self_deposit_type(self_deposit_form) || self_deposit_form&.value
+        end
+
+        def self_deposit_form
+          @self_deposit_form ||= Array(description.form).find { |cocina_form| self_deposit_form?(cocina_form) }
+        end
+
+        # @param cocina_self_deposit_form [Cocina::Models::DescriptiveValue, nil] cocina form element for
+        #   Stanford self deposit resource types
+        # @return [String, nil] the value from the structuredValue when the type is 'type'
         def self_deposit_type(cocina_self_deposit_form)
-          cocina_self_deposit_form&.structuredValue&.each do |struct_val|
-            return struct_val.value if struct_val.type == 'type'
-          end
+          cocina_self_deposit_form&.structuredValue&.find do |struct_val|
+            struct_val.type == 'type'
+          end&.value
         end
 
         def self_deposit_subtypes(cocina_self_deposit_form)

--- a/spec/datacite/validators/cocina_validator_spec.rb
+++ b/spec/datacite/validators/cocina_validator_spec.rb
@@ -289,6 +289,13 @@ RSpec.describe Datacite::Validators::CocinaValidator do
                 type: 'type'
               }
             ]
+          },
+          {
+            type: 'resource type',
+            source: {
+              value: 'Stanford self-deposit resource types'
+            },
+            value: 'Data'
           }
         ],
         identifier: [


### PR DESCRIPTION
## Why was this change made?

Fixes: https://app.honeybadger.io/projects/128495/faults/133323397

The incoming cocina for the above error looks like:

```
      {
        "value": "Data",
        "type": "resource type",
        "source": { "value": "Stanford self-deposit resource types" }
      },
```

Because we currently expect a `structuredValue`, if that isn't there the current method returns an empty array instead of `nil` causing the validation error. This now additionally looks for a simple `value` on the form object or results in nil.

## How was this change tested?



## Which documentation and/or configurations were updated?



