### PR TITLE
Add script for checking cocina valiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,16 @@ validator = Datacite::Validators::AttributesValidator.new(attributes: datacite_a
 puts validator.errors.join(', ') unless validator.valid?
 ```
 
+## Validating cocina locally
+
+With cocina json saved from arge (append `.json` to an argo view URL and save the content locally) then run:
+
+```
+bin/validate-cocina path/to/file.json
+```
+
+This will result in either a `Valid!` message or an `Invalid!` message with a list of validation errors.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -1,6 +1,10 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+# This is used to validate if a cocina object will produce
+# a valid datacite payload
+# usage: bin/validate-cocina tmp/druid.json
+
 require 'bundler/setup'
 require 'datacite'
 require 'cocina/models'

--- a/bin/validate-cocina
+++ b/bin/validate-cocina
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'datacite'
+require 'cocina/models'
+require 'json'
+
+if ARGV.empty?
+  warn "Usage: #{$PROGRAM_NAME} <path-to-cocina-json>"
+  exit 1
+end
+
+json_path = ARGV[0]
+
+unless File.exist?(json_path)
+  warn "File not found: #{json_path}"
+  exit 1
+end
+
+json = JSON.parse(File.read(json_path))
+cocina_object = Cocina::Models::DROWithMetadata.new(json)
+validator = Datacite::Validators::CocinaValidator.new(cocina_object: cocina_object)
+
+if validator.valid?
+  puts 'Valid!'
+else
+  puts 'Invalid:'
+  validator.errors.each { |error| puts "  - #{error}" }
+  exit 1
+end


### PR DESCRIPTION
## Why was this change made?

This is just a simple bin script to pass saved cocina from argo through the datacite validation locally. As this is using the cocina saved from the argo display (i.e. `https://argo.stanford.edu/items/druid:mh765ys7343.json`) it uses `DROWithMetadata` as the created/updated/lock fields are present.

## How was this change tested?



## Which documentation and/or configurations were updated?



